### PR TITLE
add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM docker.io/library/maven:3.8-jdk-11 as builder
+RUN mkdir /build
+ADD spring /build/spring
+ADD quarkus /build/quarkus
+WORKDIR /build
+RUN mvn -B clean verify -DskipTests -f spring/pom.xml
+RUN mvn -B clean verify -DskipTests -f quarkus/pom.xml
+
+FROM docker.io/library/maven:3.8-jdk-11
+RUN mkdir -p /opt/target/spring; mkdir -p /opt/target/quarkus
+COPY --from=builder /build/spring/target/* /opt/target/spring/
+COPY --from=builder /build/quarkus/target/* /opt/target/quarkus


### PR DESCRIPTION
This is the screenshot (tested without infra)

cc @holly-cummins 

```console
[root@rhel quarkus-universal-todo]# podman build -t universal-todo -f Dockerfile 
[1/2] STEP 1/7: FROM docker.io/library/maven:3.8-jdk-11 AS builder
[1/2] STEP 2/7: RUN mkdir /build
--> Using cache 7a0fc5872bde62668e6bb6281ef3312f7012d1aac5f65db7a3ef802fb86a2b12
--> 7a0fc5872bd
[1/2] STEP 3/7: ADD spring /build/spring
--> Using cache 3e7f369f568d4ed04b7ff27f9bf4e12a1f0c441f17106e535d03b969c027d438
--> 3e7f369f568
[1/2] STEP 4/7: ADD quarkus /build/quarkus
--> Using cache cf7d94e214e6954fd0457fd28832c381e6fc65933b302e7962cab3a1d21b7b54
--> cf7d94e214e
[1/2] STEP 5/7: WORKDIR /build
--> Using cache 0ba16da6cc219641063af93ea30f6aa0e0bef1382c59afc404b87523ac9aa9e4
--> 0ba16da6cc2
[1/2] STEP 6/7: RUN mvn -B clean verify -DskipTests -f spring/pom.xml
--> Using cache 84517bee1b30b9f976c15e226a672f46c56ff5b55a4fa9194151554473c3bfe7
--> 84517bee1b3
[1/2] STEP 7/7: RUN mvn -B clean verify -DskipTests -f quarkus/pom.xml
--> Using cache ac15bedbd4184669ea7837d28d2cb39e548534dcee938ddc546ec105b37d81e0
--> ac15bedbd41
[2/2] STEP 1/4: FROM docker.io/library/maven:3.8-jdk-11
[2/2] STEP 2/4: RUN mkdir -p /opt/target/spring; mkdir -p /opt/target/quarkus
--> Using cache feca1cbb5796dffb3c40e4c48ac063ed2f767cd224bde2d42f7aa73013fda6ae
--> feca1cbb579
[2/2] STEP 3/4: COPY --from=builder /build/spring/target/* /opt/target/spring/
--> Using cache c25e39d106d9e555b56a03f936ad5670d049811ff1aae8dc3f8a2ab6773a06cf
--> c25e39d106d
[2/2] STEP 4/4: COPY --from=builder /build/quarkus/target/* /opt/target/quarkus
--> Using cache a00f056377f6e37d6a7059a6f6d4ce2e03ad90e81a05689cca54107652373743
[2/2] COMMIT universal-todo
--> a00f056377f
Successfully tagged localhost/universal-todo:latest
a00f056377f6e37d6a7059a6f6d4ce2e03ad90e81a05689cca54107652373743
[root@rhel quarkus-universal-todo]# podman run -ti universal-todo  java -jar /opt/target/quarkus/quarkus-run.jar
__  ____  __  _____   ___  __ ____  ______ 
 --/ __ \/ / / / _ | / _ \/ //_/ / / / __/ 
 -/ /_/ / /_/ / __ |/ , _/ ,< / /_/ /\ \   
--\___\_\____/_/ |_/_/|_/_/|_|\____/___/   
2022-07-15 17:33:45,719 WARN  [io.agr.pool] (agroal-11) Datasource '<default>': Connection to localhost:5432 refused. Check that the hostname and port are correct and that the postmaster is accepting TCP/IP connections.
2022-07-15 17:33:45,726 WARN  [org.hib.eng.jdb.env.int.JdbcEnvironmentInitiator] (JPA Startup Thread: <default>) HHH000342: Could not obtain connection to query metadata: org.postgresql.util.PSQLException: Connection to localhost:5432 refused. Check that the hostname and port are correct and that the postmaster is accepting TCP/IP connections.
        at org.postgresql.core.v3.ConnectionFactoryImpl.openConnectionImpl(ConnectionFactoryImpl.java:301)
        at org.postgresql.core.ConnectionFactory.openConnection(ConnectionFactory.java:51)
        at org.postgresql.jdbc.PgConnection.<init>(PgConnection.java:225)
        at org.postgresql.Driver.makeConnection(Driver.java:466)
        at org.postgresql.Driver.connect(Driver.java:265)
        at io.agroal.pool.ConnectionFactory.createConnection(ConnectionFactory.java:210)
        at io.agroal.pool.ConnectionPool$CreateConnectionTask.call(ConnectionPool.java:513)
        at io.agroal.pool.ConnectionPool$CreateConnectionTask.call(ConnectionPool.java:494)
        at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
        at io.agroal.pool.util.PriorityScheduledExecutor.beforeExecute(PriorityScheduledExecutor.java:75)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1126)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
        at java.base/java.lang.Thread.run(Thread.java:829)
Caused by: java.net.ConnectException: Connection refused (Connection refused)
        at java.base/java.net.PlainSocketImpl.socketConnect(Native Method)
        at java.base/java.net.AbstractPlainSocketImpl.doConnect(AbstractPlainSocketImpl.java:412)
        at java.base/java.net.AbstractPlainSocketImpl.connectToAddress(AbstractPlainSocketImpl.java:255)
        at java.base/java.net.AbstractPlainSocketImpl.connect(AbstractPlainSocketImpl.java:237)
        at java.base/java.net.SocksSocketImpl.connect(SocksSocketImpl.java:392)
        at java.base/java.net.Socket.connect(Socket.java:609)
        at org.postgresql.core.PGStream.createSocket(PGStream.java:238)
        at org.postgresql.core.PGStream.<init>(PGStream.java:98)
        at org.postgresql.core.v3.ConnectionFactoryImpl.tryConnect(ConnectionFactoryImpl.java:100)
        at org.postgresql.core.v3.ConnectionFactoryImpl.openConnectionImpl(ConnectionFactoryImpl.java:215)
        ... 12 more

2022-07-15 17:33:45,903 WARN  [io.agr.pool] (agroal-11) Datasource '<default>': Connection to localhost:5432 refused. Check that the hostname and port are correct and that the postmaster is accepting TCP/IP connections.
2022-07-15 17:33:45,904 WARN  [org.hib.eng.jdb.spi.SqlExceptionHelper] (JPA Startup Thread: <default>) SQL Error: 0, SQLState: 08001
2022-07-15 17:33:45,904 ERROR [org.hib.eng.jdb.spi.SqlExceptionHelper] (JPA Startup Thread: <default>) Connection to localhost:5432 refused. Check that the hostname and port are correct and that the postmaster is accepting TCP/IP connections.
2022-07-15 17:33:45,945 ERROR [io.qua.run.Application] (main) Failed to start application (with profile prod): java.net.ConnectException: Connection refused (Connection refused)
        at java.base/java.net.PlainSocketImpl.socketConnect(Native Method)
        at java.base/java.net.AbstractPlainSocketImpl.doConnect(AbstractPlainSocketImpl.java:412)
        at java.base/java.net.AbstractPlainSocketImpl.connectToAddress(AbstractPlainSocketImpl.java:255)
        at java.base/java.net.AbstractPlainSocketImpl.connect(AbstractPlainSocketImpl.java:237)
        at java.base/java.net.SocksSocketImpl.connect(SocksSocketImpl.java:392)
        at java.base/java.net.Socket.connect(Socket.java:609)
        at org.postgresql.core.PGStream.createSocket(PGStream.java:238)
        at org.postgresql.core.PGStream.<init>(PGStream.java:98)
        at org.postgresql.core.v3.ConnectionFactoryImpl.tryConnect(ConnectionFactoryImpl.java:100)
        at org.postgresql.core.v3.ConnectionFactoryImpl.openConnectionImpl(ConnectionFactoryImpl.java:215)
        at org.postgresql.core.ConnectionFactory.openConnection(ConnectionFactory.java:51)
        at org.postgresql.jdbc.PgConnection.<init>(PgConnection.java:225)
        at org.postgresql.Driver.makeConnection(Driver.java:466)
        at org.postgresql.Driver.connect(Driver.java:265)
        at io.agroal.pool.ConnectionFactory.createConnection(ConnectionFactory.java:210)
        at io.agroal.pool.ConnectionPool$CreateConnectionTask.call(ConnectionPool.java:513)
        at io.agroal.pool.ConnectionPool$CreateConnectionTask.call(ConnectionPool.java:494)
        at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
        at io.agroal.pool.util.PriorityScheduledExecutor.beforeExecute(PriorityScheduledExecutor.java:75)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1126)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
        at java.base/java.lang.Thread.run(Thread.java:829)
```